### PR TITLE
feat: Implement settings management page

### DIFF
--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Setting;
+use Illuminate\Http\Request;
+
+class SettingController extends Controller
+{
+    /**
+     * Display the settings page.
+     */
+    public function index()
+    {
+        $settings = Setting::pluck('value', 'key')->all();
+        return view('settings.index', compact('settings'));
+    }
+
+    /**
+     * Update the specified settings in storage.
+     */
+    public function update(Request $request)
+    {
+        $validatedData = $request->validate([
+            'app_name' => 'required|string|max:255',
+            'academic_session' => 'nullable|string|max:255',
+            'address' => 'nullable|string',
+            'app_logo' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
+        ]);
+
+        // Update text-based settings
+        foreach ($validatedData as $key => $value) {
+            if ($key === 'app_logo') continue; // Skip file upload for now
+
+            Setting::updateOrCreate(
+                ['key' => $key],
+                ['value' => $value]
+            );
+        }
+
+        // Handle file upload for app_logo
+        if ($request->hasFile('app_logo')) {
+            // Get old logo path
+            $oldLogo = Setting::where('key', 'app_logo')->first();
+
+            // Store new logo
+            $path = $request->file('app_logo')->store('logos', 'public');
+
+            // Update database
+            Setting::updateOrCreate(
+                ['key' => 'app_logo'],
+                ['value' => $path]
+            );
+
+            // Delete old logo if it exists
+            if ($oldLogo && $oldLogo->value) {
+                \Illuminate\Support\Facades\Storage::disk('public')->delete($oldLogo->value);
+            }
+        }
+
+        return redirect()->route('settings.index')->with('success', 'Settings updated successfully.');
+    }
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+}

--- a/database/migrations/2025_08_29_064326_create_settings_table.php
+++ b/database/migrations/2025_08_29_064326_create_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -1,0 +1,64 @@
+@extends('layouts.app')
+
+@section('header', 'Application Settings')
+
+@section('content')
+<div class="max-w-4xl mx-auto">
+    <x-card>
+        <x-slot name="header">
+            <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-200">Manage Settings</h3>
+            <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">Update your application's general settings.</p>
+        </x-slot>
+
+        <form action="{{ route('settings.update') }}" method="POST" enctype="multipart/form-data">
+            @csrf
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <!-- App Name -->
+                <div class="col-span-1">
+                    <x-input-label for="app_name" :value="__('Application Name')" />
+                    <x-input id="app_name" class="block mt-1 w-full" type="text" name="app_name" :value="old('app_name', $settings['app_name'] ?? '')" required autofocus />
+                    <x-input-error :messages="$errors->get('app_name')" class="mt-2" />
+                </div>
+
+                <!-- Academic Session -->
+                <div class="col-span-1">
+                    <x-input-label for="academic_session" :value="__('Academic Session')" />
+                    <x-input id="academic_session" class="block mt-1 w-full" type="text" name="academic_session" :value="old('academic_session', $settings['academic_session'] ?? '')" placeholder="e.g., 2024-2025" />
+                    <x-input-error :messages="$errors->get('academic_session')" class="mt-2" />
+                </div>
+
+                <!-- Address -->
+                <div class="col-span-2">
+                    <x-input-label for="address" :value="__('Address')" />
+                    <x-textarea id="address" name="address" class="block mt-1 w-full">{{ old('address', $settings['address'] ?? '') }}</x-textarea>
+                    <x-input-error :messages="$errors->get('address')" class="mt-2" />
+                </div>
+
+                <!-- App Logo -->
+                <div class="col-span-2">
+                    <x-input-label for="app_logo" :value="__('Application Logo')" />
+                    <div class="mt-2 flex items-center space-x-4">
+                        @if(!empty($settings['app_logo']))
+                            <img src="{{ asset('storage/' . $settings['app_logo']) }}" alt="Current Logo" class="h-16 w-16 rounded-md object-cover bg-gray-100 dark:bg-gray-700">
+                        @else
+                            <div class="h-16 w-16 rounded-md bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
+                                <svg class="h-8 w-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l-1.586-1.586a2 2 0 00-2.828 0L6 18"></path></svg>
+                            </div>
+                        @endif
+                        <input id="app_logo" name="app_logo" type="file" class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100 dark:file:bg-gray-700 dark:file:text-gray-300 dark:hover:file:bg-gray-600"/>
+                    </div>
+                     <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">Leave blank to keep the current logo. Max file size: 2MB.</p>
+                    <x-input-error :messages="$errors->get('app_logo')" class="mt-2" />
+                </div>
+
+            </div>
+
+            <div class="flex items-center justify-end mt-8 border-t border-gray-200 dark:border-gray-700 pt-6">
+                <x-button>
+                    {{ __('Save Settings') }}
+                </x-button>
+            </div>
+        </form>
+    </x-card>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,7 @@ use App\Http\Controllers\GuardianController;
 use App\Http\Controllers\GradingScaleController;
 use App\Http\Controllers\NoticeController;
 use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\SettingController;
 use App\Http\Controllers\ResultController;
 use App\Http\Controllers\StudentController;
 use App\Http\Controllers\StudyMaterialController;
@@ -108,6 +109,10 @@ Route::middleware(['auth'])->group(function () {
 
         // Grading Scale management
         Route::resource('grading-scales', GradingScaleController::class)->except(['show']);
+
+        // Settings management
+        Route::get('settings', [SettingController::class, 'index'])->name('settings.index');
+        Route::post('settings', [SettingController::class, 'update'])->name('settings.update');
     });
     
     // Teacher routes


### PR DESCRIPTION
This commit introduces a new settings management feature for administrators.

- Creates a new `settings` table via a database migration to store key-value pairs for application settings.
- Adds a `Setting` model to interact with the new table.
- Implements a `SettingController` with `index` and `update` methods to handle displaying and saving settings.
- Includes a new view with a form where administrators can update the application name, logo, address, and academic session.
- Registers the necessary routes in `web.php` to make the feature accessible.